### PR TITLE
chore: minimize the package footprint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const semver = require("semver");
+const valid = require("semver/functions/valid");
 
 /**
  * isSemver
@@ -10,5 +10,5 @@ const semver = require("semver");
  * @return {Boolean} Returns `true` if the input is a valid semver version or `false` otherwise.
  */
 module.exports = function isSemver (input) {
-    return semver.valid(input) !== null;
+    return valid(input) !== null;
 };


### PR DESCRIPTION
According to the docs, we can also load only the module for the function that we care about to minimize the package footprint (size)

See https://github.com/npm/node-semver#usage